### PR TITLE
Add support for windows

### DIFF
--- a/src/lyto/cli.py
+++ b/src/lyto/cli.py
@@ -130,7 +130,7 @@ def ascii_qr_code(text: str):
 
     if cli_args.as_sixel:
         if os.name == "nt":
-           log.debug("Using windows, cant use sixel.")
+           print("Using windows, cant use sixel.")
         else:
             log.debug("Outputting QR code as Sixel graphics")
             file = io.BytesIO()

--- a/src/lyto/cli.py
+++ b/src/lyto/cli.py
@@ -130,17 +130,17 @@ def ascii_qr_code(text: str):
 
     if cli_args.as_sixel:
         if os.name == "nt":
-        log.debug("Using windows, cant use sixel.")
-    else:
-        log.debug("Outputting QR code as Sixel graphics")
-        file = io.BytesIO()
+           log.debug("Using windows, cant use sixel.")
+        else:
+            log.debug("Outputting QR code as Sixel graphics")
+            file = io.BytesIO()
 
-        img = qr.make_image(back_color="white", fill_color="black")
-        img.save(file)
+            img = qr.make_image(back_color="white", fill_color="black")
+            img.save(file)
 
-        writer = sixel.converter.SixelConverter(file, chromakey=True)
+            writer = sixel.converter.SixelConverter(file, chromakey=True)
 
-        return writer.getvalue()
+            return writer.getvalue()
 
     file = io.StringIO()
     qr.print_ascii(invert=True, out=file)

--- a/src/lyto/cli.py
+++ b/src/lyto/cli.py
@@ -16,7 +16,7 @@ import sys
 if sys.platform.startswith('win'):
     print("Running in windows, creating fake termios")
     pyinstall = os.path.dirname(sys.executable)
-    with open(f'{pyinstall}\termios.py', 'w') as file:
+    with open(f'{pyinstall}\\termios.py', 'w') as file:
          file.write('# fake termios here')
     print("Now importing sixel")
     import sixel

--- a/src/lyto/cli.py
+++ b/src/lyto/cli.py
@@ -20,9 +20,6 @@ if sys.platform.startswith('win'):
          file.write('# fake termios here')
     print("Now importing sixel")
     import sixel
-
-print(f"Python executable path: {python_executable_path}")   
-print(f"Python installation directory: {python_installation_directory}")
 else:
     import sixel
 from rich.logging import RichHandler

--- a/src/lyto/cli.py
+++ b/src/lyto/cli.py
@@ -277,9 +277,6 @@ def main() -> int:
         while True:
             time.sleep(0.1)
     except KeyboardInterrupt:
-        if sys.platform.startswith('win'):
-            print("Deleting created fake termios")
-            os.remove(pyinstall + "\\termios.py")
         pass
     finally:
         if sys.platform.startswith('win'):
@@ -289,5 +286,5 @@ def main() -> int:
         zc.close()
         if sys.platform.startswith('win'):
             print("Deleting created fake termios")
-            os.remove(pyinstall + "\termios.py")
+            os.remove(pyinstall + "\\termios.py")
         return 0

--- a/src/lyto/cli.py
+++ b/src/lyto/cli.py
@@ -132,6 +132,9 @@ def ascii_qr_code(text: str):
     qr.add_data(text)
 
     if cli_args.as_sixel:
+        if os.name == "nt":
+            log.debug("Using windows, cant use sixel.")
+            return 0
         log.debug("Outputting QR code as Sixel graphics")
         file = io.BytesIO()
 

--- a/src/lyto/cli.py
+++ b/src/lyto/cli.py
@@ -130,8 +130,8 @@ def ascii_qr_code(text: str):
 
     if cli_args.as_sixel:
         if os.name == "nt":
-            log.debug("Using windows, cant use sixel.")
-            return 0
+        log.debug("Using windows, cant use sixel.")
+    else:
         log.debug("Outputting QR code as Sixel graphics")
         file = io.BytesIO()
 
@@ -279,7 +279,7 @@ def main() -> int:
     except KeyboardInterrupt:
         if sys.platform.startswith('win'):
             print("Deleting created fake termios")
-            os.remove(pyinstall + "\termios.py")
+            os.remove(pyinstall + "\\termios.py")
         pass
     finally:
         if sys.platform.startswith('win'):


### PR DESCRIPTION
So, without this support, Lyto will just exit telling that "termios" library was not found. With this pr, i added so there is no error because of this and remove support of sixel in windows. No errors! yay!